### PR TITLE
Delay template filters until bp_before_group_plugin_template action.

### DIFF
--- a/includes/bpdig.php
+++ b/includes/bpdig.php
@@ -234,8 +234,10 @@ function bpdig_is_existing_doc( $is_existing_doc ) {
 
 	return true;
 }
-add_filter( 'bp_docs_is_existing_doc', 'bpdig_is_existing_doc' );
-add_filter( 'bp_docs_is_single_doc', 'bpdig_is_existing_doc' );
+add_action( 'bp_before_group_plugin_template', function() {
+	add_filter( 'bp_docs_is_existing_doc', 'bpdig_is_existing_doc' );
+	add_filter( 'bp_docs_is_single_doc', 'bpdig_is_existing_doc' );
+} );
 
 /**
  * bp_docs_is_doc_edit()
@@ -263,7 +265,9 @@ function bpdig_is_doc_create( $is_doc_create ) {
 
 	return bp_is_action_variable( BP_DOCS_CREATE_SLUG, 0 );
 }
-add_filter( 'bp_docs_is_doc_create', 'bpdig_is_doc_create' );
+add_action( 'bp_before_group_plugin_template', function() {
+	add_filter( 'bp_docs_is_doc_create', 'bpdig_is_doc_create' );
+} );
 
 /**
  * Filter the doc used for implicit capability mapping.


### PR DESCRIPTION
Hi Boone-

While troubleshooting a support request, I noticed a problem with the display of the docs pane within a group:
![Extra-doc-create-form](https://user-images.githubusercontent.com/1391994/55006975-9c7e4180-4fac-11e9-9dfd-4556e227713b.png)

I think I've solved the issue in this commit by delaying a few filters. I hope I haven't introduced any new problems, but the plugin appears to be working as expected.

Thanks!
